### PR TITLE
Fix scientific representation of floats

### DIFF
--- a/split_by_subs.py
+++ b/split_by_subs.py
@@ -180,7 +180,7 @@ try:
 			cmd.extend(['-vf',subsfilter])
 			
 
-		cmd.extend(['-ss',str(start_secs),'-to',str(end_secs)])
+		cmd.extend(['-ss',format(start_secs, 'f'),'-to',format(end_secs, 'f')])
 		if args.twitter:
 			cmd.extend([
 			'-pix_fmt', 'yuv420p', '-vcodec', 'libx264',


### PR DESCRIPTION
For cases when timestamp is too small the `str(start_secs)` gives `1.11111111111e-05`, which obviously cannot be consumed by ffmpeg as `-ss` argument value.

Simplest solution is taken from [here](https://stackoverflow.com/questions/38847690/convert-float-to-string-without-scientific-notation-and-false-precision)